### PR TITLE
feat(core): retry numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 ### Module
 
-- Changed the base url for Zerobyw. ([#12](https://github.com/yinyanfr/comic-dl/issues/12))
+- Changed the base url for Zerobyw. ([#12](https://github.com/yinyanfr/comic-dl/pull/12))
 
 ### Feature
 
-- [CLI] comic-dl now reads presets and cookies from `~/.comic-dl`. ([#13](https://github.com/yinyanfr/comic-dl/issues/13))
+- [CLI] comic-dl now reads presets and cookies from `~/.comic-dl`. ([#13](https://github.com/yinyanfr/comic-dl/pull/13))
 
   - You need to create this folder by yourself under your personal folder.
   - comic-dl reads presets from `~/.comic-dl/presets.json`.
@@ -25,10 +25,13 @@
     └─ presets.json
     ```
 
+- [core] `options.retry` now can accept a number as its value, which indicates the number of retrys (default to 1 when `true`). ([#18](https://github.com/yinyanfr/comic-dl/pull/19))
+
 ### Fix
 
-- [core] Fixed the bug where special characters are not escaped in ComicInfo.xml. ([#11](https://github.com/yinyanfr/comic-dl/issues/11))
-- [CLI] Fixed the bug that the CLI is not correctly reading paths with a `~` in presets. ([#14](https://github.com/yinyanfr/comic-dl/issues/14))
+- [core] Fixed the bug where special characters are not escaped in ComicInfo.xml. ([#11](https://github.com/yinyanfr/comic-dl/pull/11))
+- [core] Fixed the bug where `options.retry` is losing `chapter.uri`. ([#18](https://github.com/yinyanfr/comic-dl/pull/19))
+- [CLI] Fixed the bug that the CLI is not correctly reading paths with a `~` in presets. ([#14](https://github.com/yinyanfr/comic-dl/pull/15))
 
 ## 2.3.0
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -82,7 +82,7 @@ args
   .option('zip-level', 'Optional: zip level for archive, default to 5.')
   .option(
     'retry',
-    'Optional: Automatically re-download chapters with failed images.',
+    'Optional: Automatically re-download chapters with failed images (default to 1).',
   )
   .option(
     'chapters',

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -33,7 +33,7 @@ interface CliOptions {
   yes: boolean;
   maxTitleLength: number; // max-title-length
   zipLevel: number; // zip-level
-  retry: boolean;
+  retry: boolean | number;
   chapters: string | number; // 1,2,4,7 as string or a single number
   info: boolean;
   format: string;
@@ -107,7 +107,7 @@ interface SerieDownloadOptions {
   start?: number;
   end?: number;
   rename?: string;
-  retry?: boolean;
+  retry?: boolean | number;
   chapters?: number[];
   confirm?: boolean;
   info?: boolean;


### PR DESCRIPTION
closes #18 

- Fixed the bug where `options.retry` is losing `chapter.uri`.
- `options.retry` now can accept a number as its value, which indicates the number of retrys (default to 1 when `true`).